### PR TITLE
Feat: unit owner optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climate-warehouse",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "private": true,
   "bin": "build/server.js",
   "type": "module",

--- a/src/models/units/units.modeltypes.cjs
+++ b/src/models/units/units.modeltypes.cjs
@@ -29,7 +29,6 @@ module.exports = {
   // Please insert reference to labels table.
   unitOwner: {
     type: Sequelize.STRING,
-    required: true,
   },
   countryJurisdictionOfOwner: {
     type: Sequelize.STRING,

--- a/src/validations/units.validations.js
+++ b/src/validations/units.validations.js
@@ -10,7 +10,7 @@ const unitsBaseSchema = {
   // issuanceId - derived upon unit creation
   // orgUid - derived upon unit creation
   projectLocationId: Joi.string().optional(),
-  unitOwner: Joi.string().required(),
+  unitOwner: Joi.string(),
   countryJurisdictionOfOwner: Joi.string()
     .custom(pickListValidation('countries', 'countryJurisdictionOfOwner'))
     .required(),


### PR DESCRIPTION
Makes unit owner column optional

- Currently column in DB allows nulls, so it only needs checking update on API side, no DDL update needed.

![image](https://user-images.githubusercontent.com/104385099/178537806-1a41521d-e471-4200-a7b7-566e995c56ef.png)
