### PR TITLE
Stop building installers on main branch

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -2,8 +2,6 @@ name: Build Docker Image
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '**'
   pull_request:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,6 @@ name: Build Binaries
 
 on:
   push:
-    branches:
-      - main
     tags:
       - '**'
   pull_request:


### PR DESCRIPTION
The workflow for this repo (and all other climate/carbon related repos) is a little different than other Chia repos.  All work is merged first into the `develop` branch, which is tested and once production-ready, is merged from `develop` into `main`.  Once merged to `main`, a tagged release is normally immediately created.  Therefore, the binaries built from `main` are redundant of both the pull request from `develop` and of the tagged builds, which are created immediately after the merge to `main`.  This PR removes the installer builds from `main` as they are not currently used and we don't expect them to be used.  