### PR TITLE
Systemd creator script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -234,7 +234,9 @@ jobs:
           mkdir -p "deb/$CLI_DEB_BASE/DEBIAN"
           j2 -o "deb/$CLI_DEB_BASE/DEBIAN/control" build-scripts/deb/control.j2
           cp -r ${{ matrix.name }}/* "deb/$CLI_DEB_BASE/opt/climate-warehouse/"
+          cp build-scripts/deb/generate-init.sh deb/$CLI_DEB_BASE/opt/climate-warehouse/generate-init.sh
           chmod +x deb/$CLI_DEB_BASE/opt/climate-warehouse/climate-warehouse
+          chmod +x deb/$CLI_DEB_BASE/opt/climate-warehouse/generate-init.sh
           ln -s ../../opt/climate-warehouse/climate-warehouse "deb/$CLI_DEB_BASE/usr/bin/climate-warehouse"
           dpkg-deb --build --root-owner-group "deb/$CLI_DEB_BASE"
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ sudo apt-get update
 sudo apt-get install ca-certificates curl gnupg
 ```
 
-2.  Add Chia's official GPG Key:
+2.  Add Chia's official GPG Key (if you have installed Chia with `apt`, you'll have this key already):
 
 ```
 curl -sL https://repo.chia.net/FD39E6D3.pubkey.asc | sudo gpg --dearmor -o /usr/share/keyrings/chia.gpg

--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ sudo apt-get install climate-warehouse
 #### Systemd Init Script
 
 
-If running Climate Warehouse full-time on a machine, Systemd is a convenient way to manage the state of the application and ensure it starts at boot.  A [template for creating a Systemd file for Climate Warehouse can be found in the open source Chia Ansible roles](https://github.com/Chia-Network/ansible-roles/blob/main/cadt/templates/cadt.service.j2).  Copy this template to `/etc/systemd/system/cadt.service` (or `climate-warehouse.service` if you prefer) and follow the comments in the file to configure it for your use-case.  Once configured, do `sudo systemctl daemon-reload` for systemd to see the new file (do the `daemon-reload` command every time a change is made to the `.service` file).  Doing `sudo systemctl start cadt` will start Climate Warehouse and `sudo systemctl enable cadt` will set it to start at boot.  To view the logs, do `sudo journalctl -u cadt` (add the `-f` flag to monitor the log real-time).
+If running Climate Warehouse full-time on a machine, Systemd is a convenient way to manage the state of the application and ensure it starts at boot.  If installing with `apt` or with the `.deb` file, a [script](build-scripts/generate-init.sh) to automatically generate the `cadt.service` file for systemd is included.  To generate the file, run the following and follow the instructions on-screen:
+
+```
+/opt/climate-warehouse/generate-init.sh
+```
+
+This script uses the [template](https://github.com/Chia-Network/ansible-roles/blob/main/cadt/templates/cadt.service.j2) from our Ansible automation for creating a Systemd file for Climate Warehouse.  If you'd like to configure your systemd init file manually, copy this template to `/etc/systemd/system/cadt.service` (or `climate-warehouse.service` if you prefer) and follow the comments in the file to configure it for your use-case.  Once configured, do `sudo systemctl daemon-reload` for systemd to see the new file (do the `daemon-reload` command every time a change is made to the `.service` file).  Doing `sudo systemctl start cadt` will start Climate Warehouse and `sudo systemctl enable cadt` will set it to start at boot.  To view the logs, do `sudo journalctl -u cadt` (add the `-f` flag to monitor the log real-time).
 
 
 ### Installation from Source

--- a/build-scripts/deb/generate-init.sh
+++ b/build-scripts/deb/generate-init.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+#############################################################
+# Create a systemd .service file for the CADT               #
+# climate-warehouse application.                            #
+#############################################################
+
+# Determine what user this is run as
+echo "Determining what user we are running as..."
+this_user=$(whoami)
+echo "Running as ${this_user}"
+
+# Determine what the primary group of the user is
+echo "Determining the primary group of this user..."
+this_group=$(id -gn)
+echo "Primary group is ${this_group}"
+
+# See if this user has the CHIA_ROOT variable set or has a
+# directory at ~/.chia
+if [ -z "$CHIA_ROOT" ]
+then
+    echo "CHIA_ROOT variable not set, checking for ~/.chia/mainnet directory..."
+    look_for_chia_here=~/.chia/mainnet
+else
+    echo "CHIA_ROOT variable found, validating Chia directory at ${CHIA_ROOT}..."
+    look_for_chia_here=${CHIA_ROOT}
+fi
+# Check if the Chia directory exists
+if [ -d ${look_for_chia_here} ]
+then
+    echo "Found Chia directory $look_for_chia_here"
+else
+    echo ""
+    echo "ERROR! Chia root directory at ${look_for_chia_here} not found for user ${this_user}"
+    echo "This could be for the following reasons:"
+    echo "   1.  Chia not installed"
+    echo "   2.  'chia init' has not been run"
+    echo "   3.  Chia root directory somewhere other than ~/.chia"
+    echo "   4.  Script run as a user other than the one running Chia"
+    echo "Please fix the issue and try again. If using a non-standard"
+    echo "Chia root directory, set the CHIA_ROOT environment variable."
+    exit 1
+fi
+
+# Check for Chia systemd files for node, wallet, and datalayer
+chiaServices=(full-node wallet data-layer )
+foundServices=()
+for service in "${chiaServices[@]}"
+do
+    serviceFilename="/etc/systemd/system/chia-${service}.service"
+    echo "checking for ${serviceFilename}..."
+    if [ -f ${serviceFilename} ]
+    then
+        echo "Found ${serviceFilename}"
+        foundServices+=(${serviceFilename})
+    else
+        echo "${serviceFilename} not found"
+    fi
+done
+
+# Download CADT systemd template
+echo "Downloading cadt.service template file..."
+cadtServiceFile="`wget -qO- https://raw.githubusercontent.com/Chia-Network/ansible-roles/main/cadt/templates/cadt.service.j2`"
+
+# Update the "Requires" and "After" section based on which Chia
+# systemd files are available
+for service in "${chiaServices[@]}"
+do
+    # If $foundServices array does not contain the service
+    # we are looking for, comment out the line
+    if [[ ! " ${foundServices[*]} " =~ " ${service} " ]]
+    then
+        echo "Removing requirement for ${service} systemd file..."
+        cadtServiceFile=${cadtServiceFile/Requires=chia-${service}.service/#Requires=chia-${service}.service}
+        cadtServiceFile=${cadtServiceFile/After=chia-${service}.service/#After=chia-${service}.service}
+    fi
+done
+
+# Update cadt.service with the CHIA_ROOT we found
+echo "Setting the CHIA_ROOT in the cadt.service file to $look_for_chia_here..."
+cadtServiceFile=${cadtServiceFile/"{{ chia_root }}"/${look_for_chia_here}}
+
+# Find the climate-warehouse executable
+echo "Looking for climate-warehouse executable..."
+if [ -f /opt/climate-warehouse/climate-warehouse ]
+then
+    echo "climate-warehouse executable found at /opt/climate-warehouse/climate-warehouse"
+    climateWarehouseExec="/opt/climate-warehouse/climate-warehouse"
+elif [ -f ~/cadt/linux-x64/climate-warehouse ]
+then
+    echo "climate-warehouse executable found at ~/cadt/linux-x64/climate-warehouse"
+    climateWarehouseExec="/opt/climate-warehouse/climate-warehouse"
+else
+    echo ""
+    echo "Can't find climate-warehouse executable! Please enter the full path to climate-warehouse:"
+    read climateWarehouseExec
+    if [ -f ${climateWarehouseExec} ]
+    then
+        echo "climate-warehouse validated at ${climateWarehouseExec}"
+    else
+        echo "ERROR! Cannot find climate-warehouse executable at ${climateWarehouseExec}"
+        exit 1
+    fi
+fi
+
+# Set executable location in cadt.service file
+echo "Setting the CADT executable location to ${climateWarehouseExec} in cadt.service..."
+cadtServiceFile=${cadtServiceFile/'ExecStart=/home/{{ user }}/cadt/linux-x64/climate-warehouse'/ExecStart=${climateWarehouseExec}}
+
+# Set user and group in cadt.service file
+echo "Setting the user to be ${this_user} and the group to be ${this_group} in cadt.service..."
+cadtServiceFile=${cadtServiceFile/'User={{ user }}'/User=${this_user}}
+cadtServiceFile=${cadtServiceFile/'Group={{ group }}'/Group=${this_group}}
+
+# Output the cadt.service file to /etc/systemd/system/cadt.service (needs sudo)
+echo ""
+echo "Writing file to ${HOME}/cadt.service"
+printf "$cadtServiceFile" > ${HOME}/cadt.service
+echo ""
+echo "************************************"
+echo "* Your cadt.service file is ready! *"
+echo "************************************"
+echo ""
+echo ""
+echo "****************"
+echo "* Instructions *"
+echo "****************"
+echo " 1.  Move ${HOME}/cadt.service to /etc/systemd/system/cadt.service with this command:"
+echo "          sudo mv ${HOME}/cadt.service /etc/systemd/system/cadt.service"
+echo " 2.  Reload systemd:"
+echo "          sudo systemctl daemon-reload"
+echo " 3.  You may now start the CADT service with the following command:"
+echo "          sudo systemctl start cadt"
+echo " 4.  Set CADT to start at boot:"
+echo "          sudo systemctl enable cadt"
+echo " 5.  To see the latest CADT log output:"
+echo "          sudo journalctl -u cadt.service"
+
+
+

--- a/build-scripts/deb/generate-init.sh
+++ b/build-scripts/deb/generate-init.sh
@@ -26,7 +26,7 @@ else
     look_for_chia_here=${CHIA_ROOT}
 fi
 # Check if the Chia directory exists
-if [ -d ${look_for_chia_here} ]
+if [ -d "${look_for_chia_here}" ]
 then
     echo "Found Chia directory $look_for_chia_here"
 else
@@ -49,10 +49,10 @@ for service in "${chiaServices[@]}"
 do
     serviceFilename="/etc/systemd/system/chia-${service}.service"
     echo "checking for ${serviceFilename}..."
-    if [ -f ${serviceFilename} ]
+    if [ -f "${serviceFilename}" ]
     then
         echo "Found ${serviceFilename}"
-        foundServices+=(${serviceFilename})
+        foundServices+=("${serviceFilename}")
     else
         echo "${serviceFilename} not found"
     fi
@@ -60,7 +60,7 @@ done
 
 # Download CADT systemd template
 echo "Downloading cadt.service template file..."
-cadtServiceFile="`wget -qO- https://raw.githubusercontent.com/Chia-Network/ansible-roles/main/cadt/templates/cadt.service.j2`"
+cadtServiceFile=$(wget -qO- https://raw.githubusercontent.com/Chia-Network/ansible-roles/main/cadt/templates/cadt.service.j2)
 
 # Update the "Requires" and "After" section based on which Chia
 # systemd files are available
@@ -93,8 +93,8 @@ then
 else
     echo ""
     echo "Can't find climate-warehouse executable! Please enter the full path to climate-warehouse:"
-    read climateWarehouseExec
-    if [ -f ${climateWarehouseExec} ]
+    read -r climateWarehouseExec
+    if [ -f "${climateWarehouseExec}" ]
     then
         echo "climate-warehouse validated at ${climateWarehouseExec}"
     else
@@ -115,7 +115,7 @@ cadtServiceFile=${cadtServiceFile/'Group={{ group }}'/Group=${this_group}}
 # Output the cadt.service file to /etc/systemd/system/cadt.service (needs sudo)
 echo ""
 echo "Writing file to ${HOME}/cadt.service"
-printf "$cadtServiceFile" > ${HOME}/cadt.service
+printf "$cadtServiceFile" > "${HOME}"/cadt.service
 echo ""
 echo "************************************"
 echo "* Your cadt.service file is ready! *"


### PR DESCRIPTION
Bash script that automatically generates a valid systemd file to use on Ubuntu Linux systems.  Systemd allows the user to leverage the standard Linux init system to run the climate-warehouse application by issuing commands such as `systemctl start cadt` and `systemctl enable cadt`.  It is challenging to package a systemd init file in the .deb package because we would have to know the user that Chia runs as to create the cadt.service file appropriately.  This script can be run by the user after installation and

1. detects the user
2. checks if chia is installed
3. checks if there are chia systemd init files
4. downloads the cadt.service file we use in Ansible
5. modifies the cadt.service file using the checks mentioned in 1, 2, and 3
6. outputs the cadt.service file with instructions on how to install it

This script gets packaged in the .deb installer so anyone installing with `apt` or the .deb file will have the script available at `/opt/climate-warehouse/generate-init.sh`.  The README has been updated with instructions on how to use it.  

This is valuable for any enterprise users and is the way most will want to run the CADT service.  Packaging it with the .deb package makes sense to me as a way to distribute this to those who might need it, but keep it out of the way for everyone else. 