### PR TITLE
Fix error and remove home org check for metadata fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "climate-warehouse",
-  "version": "1.2.28",
+  "version": "1.2.29",
   "private": true,
   "bin": "build/server.js",
   "type": "module",

--- a/src/controllers/organization.controller.js
+++ b/src/controllers/organization.controller.js
@@ -367,7 +367,6 @@ export const addMirror = async (req, res) => {
 export const getMetaData = async (req, res) => {
   try {
     await assertWalletIsSynced();
-    await assertHomeOrgExists();
 
     const organization = await Organization.findOne({
       where: { orgUid: req.query.orgUid },
@@ -376,7 +375,7 @@ export const getMetaData = async (req, res) => {
     return res.json(JSON.parse(organization.metadata));
   } catch (error) {
     res.status(400).json({
-      message: 'Error removing mirror for organization',
+      message: 'Error getting metadata for organization',
       error: error.message,
     });
   }


### PR DESCRIPTION
Fix error message around getting metadata information
Remove home org check for metadata fetch, as this prevents the observer node from responding to this message as the observer node doesn't have any home org